### PR TITLE
Add Tomb Raider Anniversary as game

### DIFF
--- a/CDC/CDC.cs
+++ b/CDC/CDC.cs
@@ -19,7 +19,8 @@ namespace CDC
 		SR1,
 		SR2,
 		Defiance,
-		TRL
+		TRL,
+		TRA
 	}
 
 	public enum Asset

--- a/CDC/Files/DataFile.cs
+++ b/CDC/Files/DataFile.cs
@@ -282,7 +282,7 @@ namespace CDC
 				{
 					dataFile = new DefianceFile(dataFileName, objectListFile, platform, options);
 				}
-				else if (game == Game.TRL)
+				else if (game == Game.TRL || game == Game.TRA)
 				{
 					dataFile = new TRLFile(dataFileName, objectListFile, platform, options);
 				}

--- a/ModelEx/LoadResourceDialog.cs
+++ b/ModelEx/LoadResourceDialog.cs
@@ -74,7 +74,8 @@ namespace ModelEx
 			gameTypeComboBox.Items.Add("Soul Reaver 1 Files (*.drm)");
 			gameTypeComboBox.Items.Add("Soul Reaver 2 Files (*.drm)");
 			gameTypeComboBox.Items.Add("Defiance Files (*.drm)");
-			gameTypeComboBox.Items.Add("Tomb Raider Files(*.drm)");
+			gameTypeComboBox.Items.Add("Tomb Raider Legend Files(*.drm)");
+			gameTypeComboBox.Items.Add("Tomb Raider Anniversary Files(*.drm)");
 		}
 
 		private void LoadResourceDialog_Load(object sender, System.EventArgs e)
@@ -383,6 +384,7 @@ namespace ModelEx
 						case CDC.Game.SR2: rootFolderName = "pcenglish"; break;
 						case CDC.Game.Defiance: rootFolderName = "pcenglish"; break;
 						case CDC.Game.TRL: rootFolderName = "pc-w"; break;
+						case CDC.Game.TRA: rootFolderName = "pc-w"; break;
 						default: break;
 					}
 
@@ -449,6 +451,7 @@ namespace ModelEx
 							break;
 						}
 						case CDC.Game.TRL:
+						case CDC.Game.TRA:
 						{
 							textureFileComboBox.Items.Add(new FileNode(textureFileName, true));
 							break;
@@ -462,11 +465,13 @@ namespace ModelEx
 
 					#region Object List
 					string objectListFileName = fileInfo.FullName;
-					if (SelectedGameType == CDC.Game.Defiance || SelectedGameType == CDC.Game.TRL)
+					if (SelectedGameType == CDC.Game.Defiance || SelectedGameType == CDC.Game.TRL || SelectedGameType == CDC.Game.TRA)
 					{
 						if (foundRoot)
 						{
-							string gameFolderName = (SelectedGameType == CDC.Game.Defiance) ? "sr3" : "tr7";
+							string gameFolderName
+								= (SelectedGameType == CDC.Game.Defiance) ? "sr3" : (SelectedGameType == CDC.Game.TRL) ? "tr7" : "trae";
+
 							objectListFileName = Path.Combine(rootDirectory, gameFolderName, rootFolderName, "objectlist.txt");
 						}
 						else

--- a/ModelEx/Program.cs
+++ b/ModelEx/Program.cs
@@ -554,7 +554,7 @@ namespace ModelEx
 							loadRequest.TextureFile = inputFilePath;
 						}
 
-						if (loadRequest.GameType == CDC.Game.TRL)
+						if (loadRequest.GameType == CDC.Game.TRL || loadRequest.GameType == CDC.Game.TRA)
 						{
 							//
 						}


### PR DESCRIPTION
Fixes the tr7 folder name for Anniversary by adding it as seperate game, still uses the TRL code.