### PR TITLE
Add SlimDX via NuGet package

### DIFF
--- a/ModelEx/ModelEx.csproj
+++ b/ModelEx/ModelEx.csproj
@@ -63,7 +63,9 @@
     <Reference Include="AssimpNet, Version=4.1.0.0, Culture=neutral, PublicKeyToken=0d51b391f59f42a6, processorArchitecture=MSIL">
       <HintPath>packages\AssimpNet.4.1.0\lib\net40\AssimpNet.dll</HintPath>
     </Reference>
-    <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86" />
+    <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
+      <HintPath>packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />

--- a/ModelEx/packages.config
+++ b/ModelEx/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AssimpNet" version="4.1.0" targetFramework="net471" />
+  <package id="SlimDX" version="4.0.13.44" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Adds SlimDX via NuGet instead of requiring specific version of the runtime.