### PR TITLE
Fix VMO strips for TRL

### DIFF
--- a/CDC/Models/TRLModel.cs
+++ b/CDC/Models/TRLModel.cs
@@ -18,7 +18,9 @@ namespace CDC
 		protected class TRLMaterial
 		{
 			public UInt32 textureID;
+			public UInt32 flags;
 			public UInt32 vbBaseOffset;
+			public bool useExtraGeometry;
 		}
 
 		protected DataFile _dataFile;


### PR DESCRIPTION
In Legend there are two vertex buffers, one for terrain and another one for VMO terrain. The material specifies which vertex buffer should be used. Since the wrong vertex buffer is used for VMO strips the level looks corrupted.

This PR fixes the VMO strips using the right vertex buffer. The code is based on `DefianceUnitModel.cs` where it uses `_extraGeometry`. Feel free to request changes.

Before/after:
![image](https://github.com/TheSerioliOfNosgoth/ModelEx/assets/15322107/590536ba-e3f5-4995-889b-6f47554b69b7)
![image](https://github.com/TheSerioliOfNosgoth/ModelEx/assets/15322107/cdca2521-b4dd-4cb9-9ca0-3982c0de424c)

Before/after:
![image](https://github.com/TheSerioliOfNosgoth/ModelEx/assets/15322107/bb9c06c0-7f6a-4629-b370-2435a351efc8)
![image](https://github.com/TheSerioliOfNosgoth/ModelEx/assets/15322107/4fff619c-ff72-41cf-b3a1-a852334631c0)